### PR TITLE
Fix Vue directives to work for multiple parameters

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -53,7 +53,7 @@ export function createI18n (options = { messages: {}, locale: 'en', wikilinks: t
         if (!Array.isArray(params)) {
           params = [params]
         }
-        return bananai18n.i18n(msg, params)
+        return bananai18n.i18n(msg, ...params)
       }
 
       app.provide('setLocale', (newLocale) => {

--- a/src/index.js
+++ b/src/index.js
@@ -49,6 +49,10 @@ export function createI18n (options = { messages: {}, locale: 'en', wikilinks: t
       app.provide(contextSymbol, bananai18n)
 
       app.config.globalProperties.$i18n = (msg, params) => {
+        params = params || []
+        if (!Array.isArray(params)) {
+          params = [params]
+        }
         return bananai18n.i18n(msg, params)
       }
 
@@ -62,16 +66,16 @@ export function createI18n (options = { messages: {}, locale: 'en', wikilinks: t
 
         if (binding.modifiers.html) {
           // v-i18n.html or v-i18n:message_key.html
-          el.innerHTML = bananai18n.i18n(msg, params)
+          el.innerHTML = bananai18n.i18n(msg, ...params)
         } else {
-          el.textContent = bananai18n.i18n(msg, params)
+          el.textContent = bananai18n.i18n(msg, ...params)
         }
       })
 
       app.directive('i18n-html', (el, binding) => {
         const { msg, params } = parseValue(binding)
         // The content is sanitized HTML, hence innerHTML is safe.
-        el.innerHTML = bananai18n.i18n(msg, params)
+        el.innerHTML = bananai18n.i18n(msg, ...params)
       })
     }
   }

--- a/test/vue-banana.test.js
+++ b/test/vue-banana.test.js
@@ -11,7 +11,8 @@ const translations = {
     search_results: 'Found $1 {{PLURAL:$1|result|results}}',
     profile_change_message: '$1 changed {{GENDER:$2|his|her}} profile picture',
     hello_wikipedia: 'Hello [https://wikipedia.org wikipedia.org]',
-    hello_wikipedia_unsafe: 'Hello [http://wikipedia.org <script>alert( "link-script test" );</script>]'
+    hello_wikipedia_unsafe: 'Hello [http://wikipedia.org <script>alert( "link-script test" );</script>]',
+    'empty-results': 'No pages found for "$1" in $2'
   },
   ml: {
     hello_world: 'എല്ലാവർക്കും നമസ്കാരം',
@@ -106,6 +107,21 @@ describe('v-i18n directive', () => {
       }
     })
     assert.strict.equal(wrapper.text(), 'Found 11 results')
+  })
+
+  it('message with multiple parameters should be translated', () => {
+    const wrapper = mount({
+      template: '<p v-i18n:empty-results="[\'Invalid page\', \'English\']" />',
+      setup (props) {
+        const setLocale = inject('setLocale')
+        setLocale('en')
+      }
+    }, {
+      global: {
+        plugins: [i18n]
+      }
+    })
+    assert.strict.equal(wrapper.text(), 'No pages found for "Invalid page" in English')
   })
 
   it('html should be escaped', () => {

--- a/test/vue-banana.test.js
+++ b/test/vue-banana.test.js
@@ -182,3 +182,29 @@ describe('v-i18n-html directive', () => {
     assert.strict.notEqual(wrapper.find('a').attributes('href'), 'https://wikipedia.org')
   })
 })
+
+describe('Vue-Banana-i18n global $i18n with multiple params', () => {
+  let wrapper
+  beforeEach(() => {
+    wrapper = mount({
+      template: `
+          <p>{{$i18n(msg, params)}}</p>
+        `,
+      props: {
+        msg: { type: String, default: 'empty-results' },
+        params: { type: Array }
+      }
+    }, {
+      props: {
+        msg: 'empty-results',
+        params: ['Invalid page', 'English']
+      },
+      global: {
+        plugins: [i18n]
+      }
+    })
+  })
+  it('will correctly replace all placeholders while using $i18n', () => {
+    assert.strict.equal(wrapper.text(), 'No pages found for "Invalid page" in English')
+  })
+})


### PR DESCRIPTION
Vue directives do not work properly when multiple parameters
are being passed to the translation message.

This PR fixes these directives and also adds tests for this
case.