### PR TITLE
Rename ES module to .mjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-banana-i18n",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "A Banana-i18n wrapper to support localization in Vue.js",
   "author": {
     "name": "Santhosh Thottingal",
@@ -14,10 +14,10 @@
     "dist"
   ],
   "main": "./dist/vue-banana-i18n.umd.js",
-  "module": "./dist/vue-banana-i18n.es.js",
+  "module": "./dist/vue-banana-i18n.mjs",
   "exports": {
     ".": {
-      "import": "./dist/vue-banana-i18n.es.js",
+      "import": "./dist/vue-banana-i18n.mjs",
       "require": "./dist/vue-banana-i18n.umd.js"
     }
   },

--- a/vite.config.js
+++ b/vite.config.js
@@ -11,8 +11,8 @@ module.exports = defineConfig({
     minify: 'esbuild',
     lib: {
       entry: path.resolve(__dirname, 'src/index.js'),
-      name: 'vue-banana-i18n',
-      fileName: (format) => `vue-banana-i18n.${format}.js`
+      name: 'vue-banana-i18n'
+      // fileName not specified; it'll be vue-banana-i18n.mjs or vue-banana-i18n.umd.js
     },
     rollupOptions: {
       // make sure to externalize deps that shouldn't be bundled


### PR DESCRIPTION
This allows to import the vue-banana-i18n module from NodeJS environments which is useful in SSR applications like VitePress projects.

Bug: #23